### PR TITLE
Fix wrong license note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ Broadcast Utilities
 
 ## 🛡️ License
 
-MIT — see [LICENSE](LICENSE) for details.
+GPL v2.0 — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
This pull request includes a single change to the `README.md` file. The change updates the license information from MIT to GPL v2.0.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R83): Updated the license from MIT to GPL v2.0.

Fixes #10